### PR TITLE
Updating version numbers on Actions

### DIFF
--- a/templates/workflows/ci-cd.yml
+++ b/templates/workflows/ci-cd.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Build project
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist


### PR DESCRIPTION
This pull request updates the CI/CD workflow to use the latest versions of the GitHub Actions for uploading and downloading build artifacts. This helps ensure better support, security, and access to new features.

CI/CD workflow updates:

* Upgraded `actions/upload-artifact` from version 3 to version 4 in `templates/workflows/ci-cd.yml`.
* Upgraded `actions/download-artifact` from version 3 to version 4 in `templates/workflows/ci-cd.yml`.